### PR TITLE
Add missing mozrunner dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
         'pylzma',
         'pytz',
         'tzlocal',
-        'python-dateutil'
+        'python-dateutil',
+        'mozrunner',
     ],
     entry_points = {
         'console_scripts': ['amo=pyamo.cli:main']


### PR DESCRIPTION
Without this, I get an error when I run

```
python setup.py install
amo
```
